### PR TITLE
This commit adds support for the Veo2 video generation model.

### DIFF
--- a/image_utils.py
+++ b/image_utils.py
@@ -133,7 +133,7 @@ def prepare_image_for_veo(input_bytes: bytes) -> tuple[bytes, float]:
 
     current_width, current_height = resized_16_9_img.size
 
-    if original_width < min_width or original_height < min_height:
+    if current_width < min_width or current_height < min_height:
         print(f"Upscaling image from {current_width}x{current_height} to meet 720p requirement.")
         final_img = resized_16_9_img.resize((min_width, min_height), Image.Resampling.LANCZOS)
     else:
@@ -144,3 +144,68 @@ def prepare_image_for_veo(input_bytes: bytes) -> tuple[bytes, float]:
     final_img.save(output_buffer, format='PNG')
 
     return output_buffer.getvalue(), original_aspect_ratio
+
+
+def prepare_image_for_veo2(input_bytes: bytes) -> tuple[bytes, float, str]:
+    """
+    Prepares an image for the Veo2 API.
+    1. Records original aspect ratio.
+    2. Determines the closest supported aspect ratio (16:9 or 9:16).
+    3. Resizes to the target aspect ratio with fuchsia bars.
+    4. Ensures the output resolution is at least 720p.
+
+    Returns:
+        A tuple of (prepared_image_bytes, original_aspect_ratio, target_aspect_ratio_str).
+    """
+    img = Image.open(io.BytesIO(input_bytes))
+    if img.mode != 'RGB':
+        img = img.convert('RGB')
+
+    # 1. Record original aspect ratio
+    original_width, original_height = img.size
+    original_aspect_ratio = original_width / original_height
+
+    # 2. Determine closest supported aspect ratio
+    aspect_ratio_16_9 = 16.0 / 9.0
+    aspect_ratio_9_16 = 9.0 / 16.0
+
+    if abs(original_aspect_ratio - aspect_ratio_16_9) < abs(original_aspect_ratio - aspect_ratio_9_16):
+        target_ratio = aspect_ratio_16_9
+        target_ratio_str = "16:9"
+        min_width = 1280
+        min_height = 720
+    else:
+        target_ratio = aspect_ratio_9_16
+        target_ratio_str = "9:16"
+        min_width = 720
+        min_height = 1280
+
+    # 3. Resize to target aspect ratio
+    if abs(original_aspect_ratio - target_ratio) < 1e-5:
+        resized_img = img
+    else:
+        if original_aspect_ratio > target_ratio:
+            new_width = original_width
+            new_height = int(new_width / target_ratio)
+            background = Image.new('RGB', (new_width, new_height), (255, 0, 255))
+            background.paste(img, (0, (new_height - original_height) // 2))
+        else: # original_aspect_ratio < target_ratio
+            new_height = original_height
+            new_width = int(new_height * target_ratio)
+            background = Image.new('RGB', (new_width, new_height), (255, 0, 255))
+            background.paste(img, ((new_width - original_width) // 2, 0))
+        resized_img = background
+
+    # 4. Ensure resolution is at least 720p
+    current_width, current_height = resized_img.size
+    if current_width < min_width or current_height < min_height:
+        print(f"Upscaling image from {current_width}x{current_height} to meet {target_ratio_str} 720p requirement.")
+        final_img = resized_img.resize((min_width, min_height), Image.Resampling.LANCZOS)
+    else:
+        final_img = resized_img
+
+    # Convert to bytes
+    output_buffer = io.BytesIO()
+    final_img.save(output_buffer, format='PNG')
+
+    return output_buffer.getvalue(), original_aspect_ratio, target_ratio_str

--- a/templates/index.html
+++ b/templates/index.html
@@ -111,6 +111,13 @@
                             <option value="1080p">1080p (High Quality)</option>
                         </select>
                     </div>
+                    <div class="form-options" style="margin-top: 1rem;">
+                        <label for="model">Model:</label>
+                        <select name="model" id="model">
+                            <option value="veo-3.0-fast-generate-001" selected>Veo 3 Fast</option>
+                            <option value="veo-2.0-generate-001">Veo 2</option>
+                        </select>
+                    </div>
                     <div class="button-group" style="margin-top: 1rem;">
                         <button type="submit" class="btn-secondary" formaction="/resize" formmethod="post">Resize to 16:9</button>
                         <button type="submit" class="btn-primary" formaction="/generate-video" formmethod="post">Generate Video</button>

--- a/video_generator.py
+++ b/video_generator.py
@@ -84,16 +84,17 @@ def start_video_generation_job(
     output_gcs_uri_prefix: str,
     resolution: str = "720p",
     prompt: str = "A high-quality, cinematic rotation around the subject. the video format must be kept the same",
+    model_id: str = "veo-3.0-fast-generate-001",
+    aspect_ratio: str = "16:9"
 ) -> tuple[str, str]:
     """
     Starts the video generation job and returns the operation name.
     """
-    log.info("start_video_generation_job.start", project_id=project_id, location=location)
+    log.info("start_video_generation_job.start", project_id=project_id, location=location, model_id=model_id)
     creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
     auth_req = google.auth.transport.requests.Request()
     creds.refresh(auth_req)
 
-    model_id = "veo-3.0-fast-generate-001"
     start_job_url = (
         f"https://{location}-aiplatform.googleapis.com/v1/projects/{project_id}"
         f"/locations/{location}/publishers/google/models/{model_id}:predictLongRunning"
@@ -106,7 +107,13 @@ def start_video_generation_job(
     log.info("start_video_generation_job.details", model_id=model_id, job_id=str(job_id), output_uri=full_output_uri)
 
     instances = [{"prompt": prompt, "image": {"bytesBase64Encoded": encoded_image, "mimeType": "image/png"}}]
-    parameters = {"resolution": resolution, "generateAudio": False, "storageUri": full_output_uri, "sampleCount": 1}
+    parameters = {
+        "resolution": resolution,
+        "generateAudio": False,
+        "storageUri": full_output_uri,
+        "sampleCount": 1,
+        "aspectRatio": aspect_ratio
+    }
     request_body = {"instances": instances, "parameters": parameters}
 
     try:


### PR DESCRIPTION
- Adds a new image preparation function `prepare_image_for_veo2` that handles different aspect ratios (16:9 and 9:16) and ensures the image meets the minimum resolution requirements for Veo2.
- Updates the frontend with a dropdown to select between "Veo 3 Fast" and "Veo 2".
- The backend is modified to handle the model selection, call the appropriate image preparation function, and pass the correct model ID and aspect ratio to the video generation job.
- Fixes a bug in the existing `prepare_image_for_veo` function where it was using the original image dimensions for the upscaling check instead of the resized dimensions.