### PR TITLE
This commit adds an option to select the video length when using the …

### DIFF
--- a/main.py
+++ b/main.py
@@ -110,8 +110,9 @@ def generate_video_endpoint():
             input_bytes = file.read()
             resolution = request.form.get("resolution", "720p")
             model = request.form.get("model", "veo-3.0-fast-generate-001")
+            duration = request.form.get("duration", 5)
             original_filename, _ = os.path.splitext(file.filename)
-            log.info("generate_video.file_read", filename=original_filename, size=len(input_bytes), resolution=resolution, model=model)
+            log.info("generate_video.file_read", filename=original_filename, size=len(input_bytes), resolution=resolution, model=model, duration=duration)
 
             task_id = str(uuid.uuid4())
             TASKS[task_id] = {
@@ -139,7 +140,8 @@ def generate_video_endpoint():
                 output_gcs_uri_prefix=f"gs://{GCS_BUCKET}",
                 resolution=resolution,
                 model_id=model,
-                aspect_ratio=aspect_ratio
+                aspect_ratio=aspect_ratio,
+                duration=int(duration)
             )
             log.info("generate_video.job_started", task_id=task_id, operation_name=operation_name)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -118,6 +118,11 @@
                             <option value="veo-2.0-generate-001">Veo 2</option>
                         </select>
                     </div>
+                    <div class="form-options" id="duration-container" style="margin-top: 1rem; display: none;">
+                        <label for="duration">Duration (seconds):</label>
+                        <input type="range" name="duration" id="duration" min="5" max="8" value="5" oninput="this.nextElementSibling.value = this.value">
+                        <output>5</output>
+                    </div>
                     <div class="button-group" style="margin-top: 1rem;">
                         <button type="submit" class="btn-secondary" formaction="/resize" formmethod="post">Resize to 16:9</button>
                         <button type="submit" class="btn-primary" formaction="/generate-video" formmethod="post">Generate Video</button>
@@ -151,6 +156,20 @@
         const imagePreview = document.getElementById('original-image-preview');
         const imageInfo = document.getElementById('original-image-info');
         const sidebar = document.getElementById('sidebar');
+        const modelSelect = document.getElementById('model');
+        const resolutionSelect = document.getElementById('resolution');
+        const durationContainer = document.getElementById('duration-container');
+
+        modelSelect.addEventListener('change', function(event) {
+            if (this.value === 'veo-2.0-generate-001') {
+                durationContainer.style.display = 'block';
+                resolutionSelect.value = '720p';
+                resolutionSelect.disabled = true;
+            } else {
+                durationContainer.style.display = 'none';
+                resolutionSelect.disabled = false;
+            }
+        });
 
         fileInput.addEventListener('change', function(event) {
             const file = event.target.files[0];

--- a/video_generator.py
+++ b/video_generator.py
@@ -85,7 +85,8 @@ def start_video_generation_job(
     resolution: str = "720p",
     prompt: str = "A high-quality, cinematic rotation around the subject. the video format must be kept the same",
     model_id: str = "veo-3.0-fast-generate-001",
-    aspect_ratio: str = "16:9"
+    aspect_ratio: str = "16:9",
+    duration: int = 5
 ) -> tuple[str, str]:
     """
     Starts the video generation job and returns the operation name.
@@ -112,7 +113,8 @@ def start_video_generation_job(
         "generateAudio": False,
         "storageUri": full_output_uri,
         "sampleCount": 1,
-        "aspectRatio": aspect_ratio
+        "aspectRatio": aspect_ratio,
+        "duration": duration
     }
     request_body = {"instances": instances, "parameters": parameters}
 


### PR DESCRIPTION
…Veo2 model.

- Adds a duration slider (5-8 seconds) to the UI, which is only visible when the Veo2 model is selected.
- The resolution is locked to 720p when Veo2 is selected.
- The backend is updated to pass the selected duration to the video generation API.

Addresses the feedback from the previous code review:
- The cropping logic is handled by the existing `crop_video_to_aspect_ratio` function, which correctly crops the generated video back to the original image's aspect ratio. This was confirmed by re-examining the code.
- The bug fix in `prepare_image_for_veo` is intentional and correct. It ensures that the image sent to the API meets the minimum resolution requirements after being padded to the target aspect ratio.